### PR TITLE
Alternate syntax for PathP

### DIFF
--- a/src/Cubical/Primitives.agda
+++ b/src/Cubical/Primitives.agda
@@ -11,9 +11,11 @@ module Postulates where
   {-# BUILTIN PATH         Path'     #-}
   {-# BUILTIN PATHP        PathP     #-}
 
-  infix 4 _≡_
+  infix 4 _≡_ _[_≡_]
   _≡_ : ∀ {ℓ} {A : Set ℓ} → A → A → Set ℓ
   _≡_ {A = A} = PathP (λ _ → A)
+  _[_≡_] : ∀ {ℓ} (A : I → Set ℓ) → A i0 → A i1 → Set ℓ
+  _[_≡_] = PathP
 
   Path = _≡_
 


### PR DESCRIPTION
With this alternate syntax the "equality constructor"[1] for the
sigma-type can be written like so:

    module _ {ℓa ℓb : Level} {A : Set ℓa} {B : A → Set ℓb} {a b : Σ A B}
      (proj₁≡ : (λ _ → A)            [ proj₁ a ≡ proj₁ b ])
      (proj₂≡ : (λ i → B (proj₁≡ i)) [ proj₂ a ≡ proj₂ b ]) where

      Σ≡ : a ≡ b
      proj₁ (Σ≡ i) = proj₁≡ i
      proj₂ (Σ≡ i) = proj₂≡ i

[1]: p. 82 HoTT-book