### PR TITLE
Ntype refactor

### DIFF
--- a/src/Cubical/GradLemma.agda
+++ b/src/Cubical/GradLemma.agda
@@ -90,7 +90,8 @@ invEquiv {A} {B} f = invEq f , gradLemma (invEq f) (fst f) (secEq f) (retEq f)
 
 
 module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
-  propPi : (h : (x : A) → isProp (B x)) (f0 f1 : (x : A) → B x) → f0 ≡ f1
+  -- Π preserves propositionality in the following sense:
+  propPi : (h : (x : A) → isProp (B x)) → isProp ((x : A) → B x)
   propPi h f0 f1  = λ i → λ x → (h x (f0 x) (f1 x)) i
 
   lemPropF : (P : (x : A) → isProp (B x)) {a0 a1 : A}

--- a/src/Cubical/GradLemma.agda
+++ b/src/Cubical/GradLemma.agda
@@ -3,6 +3,7 @@ module Cubical.GradLemma where
 
 open import Cubical
 open import Cubical.FromStdLib
+open import Cubical.NType.Properties
 
 Square : ∀ {ℓ} {A : Set ℓ} {a0 a1 b0 b1 : A}
           (u : a0 ≡ a1) (v : b0 ≡ b1) (r0 : a0 ≡ b0) (r1 : a1 ≡ b1) → Set ℓ
@@ -82,47 +83,10 @@ isoToPath : ∀ {ℓ} {A B : Set ℓ} (f : A → B) (g : B → A)
   (s : (y : B) → f (g y) ≡ y) (t : (x : A) → g (f x) ≡ x) → A ≡ B
 isoToPath f g s t = equivToPath (_ , gradLemma f g s t)
 
-lemProp : ∀ {ℓ} {A : Set ℓ} → (A → isProp A) → isProp A
-lemProp h = λ a → h a a
-
-invEquiv : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A ≃ B) → B ≃ A
+invEquiv : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → B ≃ A
 invEquiv {A} {B} f = invEq f , gradLemma (invEq f) (fst f) (secEq f) (retEq f)
 
-
-module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
-  -- Π preserves propositionality in the following sense:
-  propPi : (h : (x : A) → isProp (B x)) → isProp ((x : A) → B x)
-  propPi h f0 f1  = λ i → λ x → (h x (f0 x) (f1 x)) i
-
-  lemPropF : (P : (x : A) → isProp (B x)) {a0 a1 : A}
-    (p : a0 ≡ a1) {b0 : B a0} {b1 : B a1} → PathP (λ i → B (p i)) b0 b1
-  lemPropF P p {b0} {b1} = λ i → P (p i)
-     (primComp (λ j → B (p (i ∧ j)) ) (~ i) (λ _ →  λ { (i = i0) → b0 }) b0)
-     (primComp (λ j → B (p (i ∨ ~ j)) ) (i) (λ _ → λ{ (i = i1) → b1 }) b1) i
-
-  lemSig : (pB : (x : A) → isProp (B x))
-    (u v : Σ A B) (p : fst u ≡ fst v) → u ≡ v
-  lemSig pB u v p = λ i → (p i) , ((lemPropF pB p) {snd u} {snd v} i)
-
-  propSig : (pA : isProp A) (pB : (x : A) → isProp (B x)) → isProp (Σ A B)
-  propSig pA pB t u = lemSig pB t u (pA (fst t) (fst u))
-
-
-module _ {ℓ} {A : Set ℓ} where
-  propSet : isProp A → isSet A
-  propSet h = λ(a b : A) (p q : a ≡ b) j i →
-    primComp (λ k → A)((~ i ∨ i) ∨ (~ j ∨ j))
-      (λ k → λ { (i = i0) → h a a k; (i = i1) → h a b k
-               ; (j = i0) → h a (p i) k; (j = i1) → h a (q i) k }) a
-
-  propIsContr : isProp (isContr A)
-  propIsContr = lemProp (λ t → propSig (λ a b → trans (sym (snd t a)) (snd t b))
-         (λ x → propPi (propSet ((λ a b → trans (sym (snd t a)) (snd t b))) x)))
-
 module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'}  where
-  propIsEquiv : (f : A → B) → isProp (isEquiv A B f)
-  propIsEquiv f = λ u0 u1 → λ i → λ y → propIsContr (u0 y) (u1 y) i
-
   invEquivInvol : (f : A ≃ B) → invEquiv (invEquiv f) ≡ f
   invEquivInvol f = λ i → fst f , (propIsEquiv (fst f)
                                                (snd (invEquiv (invEquiv f)))

--- a/src/Cubical/NType.agda
+++ b/src/Cubical/NType.agda
@@ -1,11 +1,8 @@
-{-# OPTIONS --without-K --cubical #-}
+{-# OPTIONS --cubical #-}
+module Cubical.NType where
 
 open import Cubical.FromStdLib
-open import Cubical.PathPrelude
--- open import lib.Relation
-
-
-module Cubical.NType where
+open import Cubical.Primitives
 
 -- Taken from HoTT-Agda. https://github.com/HoTT/HoTT-Agda
 
@@ -16,13 +13,30 @@ data TLevel : Set where
 
 ℕ₋₂ = TLevel
 
+⟨-1⟩ ⟨0⟩ : TLevel
+⟨-1⟩ = S ⟨-2⟩
+⟨0⟩  = S ⟨-1⟩
+
 ⟨_⟩₋₂ : ℕ → ℕ₋₂
 ⟨ zero ⟩₋₂ = ⟨-2⟩
 ⟨ suc n ⟩₋₂ = S ⟨ n ⟩₋₂
 
+{-# BUILTIN FROMNAT ⟨_⟩₋₂ #-}
+
+-- A formulation of homotopy levels without wrapping it in a constructor as is
+-- done below.
+module _ {ℓ : Level} where
+  import Cubical.PathPrelude
+  -- Definition of the homotopy level of a type.
+  --
+  -- `HasLevel` is defined this way for backwards compatibility - it differs from
+  -- the version with constructors below.
+  HasLevel : TLevel → Set ℓ → Set ℓ
+  HasLevel ⟨-2⟩     = Cubical.PathPrelude.isContr
+  HasLevel (S ⟨-2⟩) = Cubical.PathPrelude.isProp
+  HasLevel (S (S n)) A = (x y : A) → HasLevel (S n) (x ≡ y)
 
 module _ {i} where
-
   {- Definition of contractible types and truncation levels -}
 
   -- We define `has-level' as a record, so that it does not unfold when

--- a/src/Cubical/NType.agda
+++ b/src/Cubical/NType.agda
@@ -26,14 +26,23 @@ data TLevel : Set where
 -- A formulation of homotopy levels without wrapping it in a constructor as is
 -- done below.
 module _ {ℓ : Level} where
-  import Cubical.PathPrelude
+  module _ (A : Set ℓ) where
+    isContr : Set ℓ
+    isContr = Σ[ x ∈ A ] (∀ y → x ≡ y)
+
+    isProp  : Set ℓ
+    isProp  = (x y : A) → x ≡ y
+
+    isSet   : Set ℓ
+    isSet   = (x y : A) → (p q : x ≡ y) → p ≡ q
+
   -- Definition of the homotopy level of a type.
   --
   -- `HasLevel` is defined this way for backwards compatibility - it differs from
   -- the version with constructors below.
   HasLevel : TLevel → Set ℓ → Set ℓ
-  HasLevel ⟨-2⟩     = Cubical.PathPrelude.isContr
-  HasLevel (S ⟨-2⟩) = Cubical.PathPrelude.isProp
+  HasLevel ⟨-2⟩     = isContr
+  HasLevel (S ⟨-2⟩) = isProp
   HasLevel (S (S n)) A = (x y : A) → HasLevel (S n) (x ≡ y)
 
 module _ {i} where

--- a/src/Cubical/NType/Properties.agda
+++ b/src/Cubical/NType/Properties.agda
@@ -1,0 +1,43 @@
+{-# OPTIONS --cubical #-}
+module Cubical.NType.Properties where
+
+open import Cubical.PathPrelude
+open import Cubical.FromStdLib
+
+lemProp : ∀ {ℓ} {A : Set ℓ} → (A → isProp A) → isProp A
+lemProp h = λ a → h a a
+
+module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
+  -- Π preserves propositionality in the following sense:
+  propPi : (h : (x : A) → isProp (B x)) → isProp ((x : A) → B x)
+  propPi h f0 f1  = λ i → λ x → (h x (f0 x) (f1 x)) i
+
+  -- `lemPropF` can be used to prove equalities in the dependent function space
+  -- of propositions.
+  lemPropF : (P : (x : A) → isProp (B x)) {a0 a1 : A}
+    (p : a0 ≡ a1) {b0 : B a0} {b1 : B a1} → PathP (λ i → B (p i)) b0 b1
+  lemPropF P p {b0} {b1} = λ i → P (p i)
+     (primComp (λ j → B (p (i ∧ j)) ) (~ i) (λ _ →  λ { (i = i0) → b0 }) b0)
+     (primComp (λ j → B (p (i ∨ ~ j)) ) (i) (λ _ → λ{ (i = i1) → b1 }) b1) i
+
+  lemSig : (pB : (x : A) → isProp (B x))
+    (u v : Σ A B) (p : fst u ≡ fst v) → u ≡ v
+  lemSig pB u v p = λ i → (p i) , ((lemPropF pB p) {snd u} {snd v} i)
+
+  propSig : (pA : isProp A) (pB : (x : A) → isProp (B x)) → isProp (Σ A B)
+  propSig pA pB t u = lemSig pB t u (pA (fst t) (fst u))
+
+module _ {ℓ} {A : Set ℓ} where
+  propSet : isProp A → isSet A
+  propSet h = λ(a b : A) (p q : a ≡ b) j i →
+    primComp (λ k → A)((~ i ∨ i) ∨ (~ j ∨ j))
+      (λ k → λ { (i = i0) → h a a k; (i = i1) → h a b k
+               ; (j = i0) → h a (p i) k; (j = i1) → h a (q i) k }) a
+
+  propIsContr : isProp (isContr A)
+  propIsContr = lemProp (λ t → propSig (λ a b → trans (sym (snd t a)) (snd t b))
+         (λ x → propPi (propSet ((λ a b → trans (sym (snd t a)) (snd t b))) x)))
+
+module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'}  where
+  propIsEquiv : (f : A → B) → isProp (isEquiv A B f)
+  propIsEquiv f = λ u0 u1 → λ i → λ y → propIsContr (u0 y) (u1 y) i

--- a/src/Cubical/PathPrelude.agda
+++ b/src/Cubical/PathPrelude.agda
@@ -4,6 +4,7 @@ module Cubical.PathPrelude where
 open import Cubical.Primitives public
 open import Cubical.Primitives public using () renaming (Sub to _[_↦_])
 open import Cubical.FromStdLib
+open import Cubical.NType public using (isContr ; isProp ; isSet)
 
 module _ {ℓ} {A : Set ℓ} where
   refl : {x : A} → x ≡ x
@@ -131,16 +132,6 @@ module _ {ℓa ℓb} {A : Set ℓa} {B : A → Set ℓb} where
   funExtImp : {f g : {x : A} → B x} → ((x : A) → f {x} ≡ g {x}) →
                                        {x : A} → f {x} ≡ g {x}
   funExtImp p {x} = λ i → p x i
-
-module _ {ℓ} (A : Set ℓ) where
-  isContr : Set ℓ
-  isContr = Σ[ x ∈ A ] (∀ y → x ≡ y)
-
-  isProp  : Set ℓ
-  isProp  = (x y : A) → x ≡ y
-
-  isSet   : Set ℓ
-  isSet   = (x y : A) → (p q : x ≡ y) → p ≡ q
 
 module _ {ℓ} {A : Set ℓ} where
   contr : isContr A → (φ : I) → (u : Partial A φ) → A

--- a/src/Cubical/Sigma.agda
+++ b/src/Cubical/Sigma.agda
@@ -7,6 +7,7 @@ open import Cubical.PathPrelude
 open import Cubical.GradLemma
 open import Cubical.Sub
 open import Cubical.FromStdLib
+open import Cubical.NType.Properties
 
 and : ∀ {ℓ} (A : Set ℓ) (B : Set ℓ) → Set ℓ
 and A B = Σ A (λ _ → B)

--- a/src/Cubical/Univalence.agda
+++ b/src/Cubical/Univalence.agda
@@ -5,7 +5,7 @@ open import Cubical hiding (_≃_; idEquiv)
 open import Cubical.FromStdLib
 open import Cubical.GradLemma
 open import Cubical.Retract
-
+open import Cubical.NType.Properties using (lemPropF ; propIsEquiv ; propSet)
 
 
 


### PR DESCRIPTION
Move results about homotopy levels to own module.

Also moves the definition of `is{Contr,Prop,Set}` from `PathPrelude` - but reexports it from here.