### PR TITLE
Alternate prelude

### DIFF
--- a/examples/Cubical/Examples/AIM_Demo/DemoPartial.agda
+++ b/examples/Cubical/Examples/AIM_Demo/DemoPartial.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --cubical #-}
 module Cubical.Examples.AIM_Demo.DemoPartial where
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.PathPrelude hiding (trans)
 
 

--- a/examples/Cubical/Examples/AIM_Demo/DemoUniv.agda
+++ b/examples/Cubical/Examples/AIM_Demo/DemoUniv.agda
@@ -2,7 +2,7 @@
 module Cubical.Examples.AIM_Demo.DemoUniv where
 
 open import Cubical.PathPrelude renaming (equivToPath to ua)
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 open import Cubical.Examples.NotIsEquiv using (not; notIsEquiv)
 

--- a/examples/Cubical/Examples/BinNat.agda
+++ b/examples/Cubical/Examples/BinNat.agda
@@ -3,7 +3,7 @@ module Cubical.Examples.BinNat where
 
 open import Cubical.Examples.CTT.Data.Nat
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.PathPrelude
 open import Cubical.GradLemma
 open import Cubical.Univalence

--- a/examples/Cubical/Examples/CTT/Data/Nat.agda
+++ b/examples/Cubical/Examples/CTT/Data/Nat.agda
@@ -1,7 +1,7 @@
 module Cubical.Examples.CTT.Data.Nat where
 
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 caseNat : ∀{l} → {A : Set l} → (a0 aS : A) → ℕ → A
 caseNat a0 aS zero = a0

--- a/examples/Cubical/Examples/Category.agda
+++ b/examples/Cubical/Examples/Category.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --cubical #-}
 module Cubical.Examples.Category where
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.PathPrelude
 
 -- Functor

--- a/examples/Cubical/Examples/Circle.agda
+++ b/examples/Cubical/Examples/Circle.agda
@@ -2,7 +2,7 @@
 
 module Cubical.Examples.Circle where
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.PathPrelude
 open import Cubical.Rewrite
 

--- a/examples/Cubical/Examples/Cube.agda
+++ b/examples/Cubical/Examples/Cube.agda
@@ -3,7 +3,7 @@ module Cubical.Examples.Cube where
 
 open import Cubical.PathPrelude
 open import Cubical.Id
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 test-sym : ∀ {ℓ} {A : Set ℓ} → {x y : A} → (p : x ≡ y) → sym (sym p) ≡ p
 test-sym p = refl

--- a/examples/Cubical/Examples/FunctorCWF.agda
+++ b/examples/Cubical/Examples/FunctorCWF.agda
@@ -2,7 +2,7 @@
 module Cubical.Examples.FunctorCWF where
 
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib hiding (_∘_)
+open import Cubical.Prelude hiding (_∘_)
 
 Σ= : ∀ {a b} {A : Set a} {B : A → Set b} {x y : Σ A B} (eq : x .fst ≡ y .fst)
      → PathP (\ i → B (eq i)) (x .snd) (y .snd) → x ≡ y

--- a/examples/Cubical/Examples/Int.agda
+++ b/examples/Cubical/Examples/Int.agda
@@ -1,6 +1,6 @@
 module Cubical.Examples.Int where
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.PathPrelude
 open import Cubical.GradLemma
 

--- a/examples/Cubical/Examples/IsSetSigma.agda
+++ b/examples/Cubical/Examples/IsSetSigma.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --cubical #-}
 module Cubical.Examples.IsSetSigma where
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.Comp
 
 

--- a/examples/Cubical/Examples/NotIsEquiv.agda
+++ b/examples/Cubical/Examples/NotIsEquiv.agda
@@ -1,7 +1,7 @@
 module Cubical.Examples.NotIsEquiv where
 
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 not : Bool → Bool
 not true = false

--- a/examples/Cubical/Examples/OTTU.agda
+++ b/examples/Cubical/Examples/OTTU.agda
@@ -2,7 +2,7 @@
 module Cubical.Examples.OTTU where
 
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 open import Cubical.Examples.Cube
 

--- a/examples/Cubical/Examples/PushOut/Int.agda
+++ b/examples/Cubical/Examples/PushOut/Int.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --cubical #-}
 module Cubical.Examples.PushOut.Int where
 
-open import Cubical.FromStdLib hiding (_+_)
+open import Cubical.Prelude hiding (_+_)
 open import Cubical.PathPrelude
 open import Cubical.GradLemma
 open import Cubical.PushOut renaming (primPushOutElim to PO-elim; P to PushOut)

--- a/examples/Cubical/Examples/SizedStream.agda
+++ b/examples/Cubical/Examples/SizedStream.agda
@@ -2,7 +2,7 @@
 module Cubical.Examples.SizedStream where
 
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib using (_×_)
+open import Cubical.Prelude using (_×_)
 open import Agda.Builtin.Size
 
 record Stream (A : Set) (i : Size) : Set where

--- a/examples/Cubical/Examples/Stream.agda
+++ b/examples/Cubical/Examples/Stream.agda
@@ -2,7 +2,7 @@
 
 module Cubical.Examples.Stream where
 
-open import Cubical.FromStdLib using (_×_; ℕ; zero; suc)
+open import Cubical.Prelude using (_×_; ℕ; zero; suc)
 open import Cubical.PathPrelude
 
 

--- a/examples/Cubical/Tests/PushOut.agda
+++ b/examples/Cubical/Tests/PushOut.agda
@@ -3,7 +3,7 @@ module Cubical.Tests.PushOut where
 
 open import Cubical.PathPrelude
 open import Cubical.Sub
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.PushOut
 
 primFwd : ∀ {l : I → Level} (A : (i : I) → Set (l i)) → (r : I) → A r → A i1
@@ -42,7 +42,7 @@ module Elim {l m} {A B C : Set l} {f : C → A} {g : C → B} (M : P f g -> Set 
      test4 = refl
 
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 module PrimComp {l : I → Level} {A B C : (i : I) → Set (l i)} {f : ∀ i → C i → A i} {g : ∀ i → C i → B i}
                     (let P = \ (i : I) → P (f i) (g i))
                     (φ : I) (u : ∀ i → Partial (P i) φ) (u0 : Sub (P i0) φ (u i0)) where

--- a/src/Cubical/GradLemma.agda
+++ b/src/Cubical/GradLemma.agda
@@ -2,7 +2,7 @@
 module Cubical.GradLemma where
 
 open import Cubical
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.NType.Properties
 
 Square : ∀ {ℓ} {A : Set ℓ} {a0 a1 b0 b1 : A}

--- a/src/Cubical/GradLemma.agda
+++ b/src/Cubical/GradLemma.agda
@@ -90,7 +90,8 @@ invEquiv {A} {B} f = invEq f , gradLemma (invEq f) (fst f) (secEq f) (retEq f)
 
 
 module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
-  propPi : (h : (x : A) → isProp (B x)) (f0 f1 : (x : A) → B x) → f0 ≡ f1
+  -- Π preserves propositionality in the following sense:
+  propPi : (h : (x : A) → isProp (B x)) → isProp ((x : A) → B x)
   propPi h f0 f1  = λ i → λ x → (h x (f0 x) (f1 x)) i
 
   lemPropF : (P : (x : A) → isProp (B x)) {a0 a1 : A}

--- a/src/Cubical/GradLemma.agda
+++ b/src/Cubical/GradLemma.agda
@@ -3,6 +3,7 @@ module Cubical.GradLemma where
 
 open import Cubical
 open import Cubical.FromStdLib
+open import Cubical.NType.Properties
 
 Square : ∀ {ℓ} {A : Set ℓ} {a0 a1 b0 b1 : A}
           (u : a0 ≡ a1) (v : b0 ≡ b1) (r0 : a0 ≡ b0) (r1 : a1 ≡ b1) → Set ℓ
@@ -82,47 +83,10 @@ isoToPath : ∀ {ℓ} {A B : Set ℓ} (f : A → B) (g : B → A)
   (s : (y : B) → f (g y) ≡ y) (t : (x : A) → g (f x) ≡ x) → A ≡ B
 isoToPath f g s t = equivToPath (_ , gradLemma f g s t)
 
-lemProp : ∀ {ℓ} {A : Set ℓ} → (A → isProp A) → isProp A
-lemProp h = λ a → h a a
-
-invEquiv : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} (f : A ≃ B) → B ≃ A
+invEquiv : ∀ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} → A ≃ B → B ≃ A
 invEquiv {A} {B} f = invEq f , gradLemma (invEq f) (fst f) (secEq f) (retEq f)
 
-
-module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
-  -- Π preserves propositionality in the following sense:
-  propPi : (h : (x : A) → isProp (B x)) → isProp ((x : A) → B x)
-  propPi h f0 f1  = λ i → λ x → (h x (f0 x) (f1 x)) i
-
-  lemPropF : (P : (x : A) → isProp (B x)) {a0 a1 : A}
-    (p : a0 ≡ a1) {b0 : B a0} {b1 : B a1} → PathP (λ i → B (p i)) b0 b1
-  lemPropF P p {b0} {b1} = λ i → P (p i)
-     (primComp (λ j → B (p (i ∧ j)) ) (~ i) (λ _ →  λ { (i = i0) → b0 }) b0)
-     (primComp (λ j → B (p (i ∨ ~ j)) ) (i) (λ _ → λ{ (i = i1) → b1 }) b1) i
-
-  lemSig : (pB : (x : A) → isProp (B x))
-    (u v : Σ A B) (p : fst u ≡ fst v) → u ≡ v
-  lemSig pB u v p = λ i → (p i) , ((lemPropF pB p) {snd u} {snd v} i)
-
-  propSig : (pA : isProp A) (pB : (x : A) → isProp (B x)) → isProp (Σ A B)
-  propSig pA pB t u = lemSig pB t u (pA (fst t) (fst u))
-
-
-module _ {ℓ} {A : Set ℓ} where
-  propSet : isProp A → isSet A
-  propSet h = λ(a b : A) (p q : a ≡ b) j i →
-    primComp (λ k → A)((~ i ∨ i) ∨ (~ j ∨ j))
-      (λ k → λ { (i = i0) → h a a k; (i = i1) → h a b k
-               ; (j = i0) → h a (p i) k; (j = i1) → h a (q i) k }) a
-
-  propIsContr : isProp (isContr A)
-  propIsContr = lemProp (λ t → propSig (λ a b → trans (sym (snd t a)) (snd t b))
-         (λ x → propPi (propSet ((λ a b → trans (sym (snd t a)) (snd t b))) x)))
-
 module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'}  where
-  propIsEquiv : (f : A → B) → isProp (isEquiv A B f)
-  propIsEquiv f = λ u0 u1 → λ i → λ y → propIsContr (u0 y) (u1 y) i
-
   invEquivInvol : (f : A ≃ B) → invEquiv (invEquiv f) ≡ f
   invEquivInvol f = λ i → fst f , (propIsEquiv (fst f)
                                                (snd (invEquiv (invEquiv f)))

--- a/src/Cubical/NType.agda
+++ b/src/Cubical/NType.agda
@@ -1,11 +1,8 @@
-{-# OPTIONS --without-K --cubical #-}
+{-# OPTIONS --cubical #-}
+module Cubical.NType where
 
 open import Cubical.FromStdLib
-open import Cubical.PathPrelude
--- open import lib.Relation
-
-
-module Cubical.NType where
+open import Cubical.Primitives
 
 -- Taken from HoTT-Agda. https://github.com/HoTT/HoTT-Agda
 
@@ -16,13 +13,30 @@ data TLevel : Set where
 
 ℕ₋₂ = TLevel
 
+⟨-1⟩ ⟨0⟩ : TLevel
+⟨-1⟩ = S ⟨-2⟩
+⟨0⟩  = S ⟨-1⟩
+
 ⟨_⟩₋₂ : ℕ → ℕ₋₂
 ⟨ zero ⟩₋₂ = ⟨-2⟩
 ⟨ suc n ⟩₋₂ = S ⟨ n ⟩₋₂
 
+{-# BUILTIN FROMNAT ⟨_⟩₋₂ #-}
+
+-- A formulation of homotopy levels without wrapping it in a constructor as is
+-- done below.
+module _ {ℓ : Level} where
+  import Cubical.PathPrelude
+  -- Definition of the homotopy level of a type.
+  --
+  -- `HasLevel` is defined this way for backwards compatibility - it differs from
+  -- the version with constructors below.
+  HasLevel : TLevel → Set ℓ → Set ℓ
+  HasLevel ⟨-2⟩     = Cubical.PathPrelude.isContr
+  HasLevel (S ⟨-2⟩) = Cubical.PathPrelude.isProp
+  HasLevel (S (S n)) A = (x y : A) → HasLevel (S n) (x ≡ y)
 
 module _ {i} where
-
   {- Definition of contractible types and truncation levels -}
 
   -- We define `has-level' as a record, so that it does not unfold when

--- a/src/Cubical/NType.agda
+++ b/src/Cubical/NType.agda
@@ -1,7 +1,7 @@
 {-# OPTIONS --cubical #-}
 module Cubical.NType where
 
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.Primitives
 
 -- Taken from HoTT-Agda. https://github.com/HoTT/HoTT-Agda

--- a/src/Cubical/NType.agda
+++ b/src/Cubical/NType.agda
@@ -26,14 +26,23 @@ data TLevel : Set where
 -- A formulation of homotopy levels without wrapping it in a constructor as is
 -- done below.
 module _ {ℓ : Level} where
-  import Cubical.PathPrelude
+  module _ (A : Set ℓ) where
+    isContr : Set ℓ
+    isContr = Σ[ x ∈ A ] (∀ y → x ≡ y)
+
+    isProp  : Set ℓ
+    isProp  = (x y : A) → x ≡ y
+
+    isSet   : Set ℓ
+    isSet   = (x y : A) → (p q : x ≡ y) → p ≡ q
+
   -- Definition of the homotopy level of a type.
   --
   -- `HasLevel` is defined this way for backwards compatibility - it differs from
   -- the version with constructors below.
   HasLevel : TLevel → Set ℓ → Set ℓ
-  HasLevel ⟨-2⟩     = Cubical.PathPrelude.isContr
-  HasLevel (S ⟨-2⟩) = Cubical.PathPrelude.isProp
+  HasLevel ⟨-2⟩     = isContr
+  HasLevel (S ⟨-2⟩) = isProp
   HasLevel (S (S n)) A = (x y : A) → HasLevel (S n) (x ≡ y)
 
 module _ {i} where

--- a/src/Cubical/NType/Properties.agda
+++ b/src/Cubical/NType/Properties.agda
@@ -2,7 +2,7 @@
 module Cubical.NType.Properties where
 
 open import Cubical.PathPrelude
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 lemProp : ∀ {ℓ} {A : Set ℓ} → (A → isProp A) → isProp A
 lemProp h = λ a → h a a

--- a/src/Cubical/NType/Properties.agda
+++ b/src/Cubical/NType/Properties.agda
@@ -1,0 +1,43 @@
+{-# OPTIONS --cubical #-}
+module Cubical.NType.Properties where
+
+open import Cubical.PathPrelude
+open import Cubical.FromStdLib
+
+lemProp : ∀ {ℓ} {A : Set ℓ} → (A → isProp A) → isProp A
+lemProp h = λ a → h a a
+
+module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
+  -- Π preserves propositionality in the following sense:
+  propPi : (h : (x : A) → isProp (B x)) → isProp ((x : A) → B x)
+  propPi h f0 f1  = λ i → λ x → (h x (f0 x) (f1 x)) i
+
+  -- `lemPropF` can be used to prove equalities in the dependent function space
+  -- of propositions.
+  lemPropF : (P : (x : A) → isProp (B x)) {a0 a1 : A}
+    (p : a0 ≡ a1) {b0 : B a0} {b1 : B a1} → PathP (λ i → B (p i)) b0 b1
+  lemPropF P p {b0} {b1} = λ i → P (p i)
+     (primComp (λ j → B (p (i ∧ j)) ) (~ i) (λ _ →  λ { (i = i0) → b0 }) b0)
+     (primComp (λ j → B (p (i ∨ ~ j)) ) (i) (λ _ → λ{ (i = i1) → b1 }) b1) i
+
+  lemSig : (pB : (x : A) → isProp (B x))
+    (u v : Σ A B) (p : fst u ≡ fst v) → u ≡ v
+  lemSig pB u v p = λ i → (p i) , ((lemPropF pB p) {snd u} {snd v} i)
+
+  propSig : (pA : isProp A) (pB : (x : A) → isProp (B x)) → isProp (Σ A B)
+  propSig pA pB t u = lemSig pB t u (pA (fst t) (fst u))
+
+module _ {ℓ} {A : Set ℓ} where
+  propSet : isProp A → isSet A
+  propSet h = λ(a b : A) (p q : a ≡ b) j i →
+    primComp (λ k → A)((~ i ∨ i) ∨ (~ j ∨ j))
+      (λ k → λ { (i = i0) → h a a k; (i = i1) → h a b k
+               ; (j = i0) → h a (p i) k; (j = i1) → h a (q i) k }) a
+
+  propIsContr : isProp (isContr A)
+  propIsContr = lemProp (λ t → propSig (λ a b → trans (sym (snd t a)) (snd t b))
+         (λ x → propPi (propSet ((λ a b → trans (sym (snd t a)) (snd t b))) x)))
+
+module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'}  where
+  propIsEquiv : (f : A → B) → isProp (isEquiv A B f)
+  propIsEquiv f = λ u0 u1 → λ i → λ y → propIsContr (u0 y) (u1 y) i

--- a/src/Cubical/PathPrelude.agda
+++ b/src/Cubical/PathPrelude.agda
@@ -4,6 +4,7 @@ module Cubical.PathPrelude where
 open import Cubical.Primitives public
 open import Cubical.Primitives public using () renaming (Sub to _[_↦_])
 open import Cubical.FromStdLib
+open import Cubical.NType public using (isContr ; isProp ; isSet)
 
 module _ {ℓ} {A : Set ℓ} where
   refl : {x : A} → x ≡ x
@@ -131,16 +132,6 @@ module _ {ℓa ℓb} {A : Set ℓa} {B : A → Set ℓb} where
   funExtImp : {f g : {x : A} → B x} → ((x : A) → f {x} ≡ g {x}) →
                                        {x : A} → f {x} ≡ g {x}
   funExtImp p {x} = λ i → p x i
-
-module _ {ℓ} (A : Set ℓ) where
-  isContr : Set ℓ
-  isContr = Σ[ x ∈ A ] (∀ y → x ≡ y)
-
-  isProp  : Set ℓ
-  isProp  = (x y : A) → x ≡ y
-
-  isSet   : Set ℓ
-  isSet   = (x y : A) → (p q : x ≡ y) → p ≡ q
 
 module _ {ℓ} {A : Set ℓ} where
   contr : isContr A → (φ : I) → (u : Partial A φ) → A

--- a/src/Cubical/PathPrelude.agda
+++ b/src/Cubical/PathPrelude.agda
@@ -1,9 +1,15 @@
+{-
+- Do not import this module!
+-
+- In stead you should use `Cubical.Prelude`.
+-}
+
 {-# OPTIONS --cubical #-}
 module Cubical.PathPrelude where
 
 open import Cubical.Primitives public
 open import Cubical.Primitives public using () renaming (Sub to _[_↦_])
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.NType public using (isContr ; isProp ; isSet)
 
 module _ {ℓ} {A : Set ℓ} where

--- a/src/Cubical/Prelude.agda
+++ b/src/Cubical/Prelude.agda
@@ -1,0 +1,3 @@
+module Cubical.Prelude where
+
+open import Cubical.FromStdLib public

--- a/src/Cubical/PushOut.agda
+++ b/src/Cubical/PushOut.agda
@@ -3,7 +3,7 @@ module Cubical.PushOut where
 
 open import Cubical.PathPrelude
 open import Cubical.Sub
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 postulate
   P : ∀ {l} → {A B C : Set l} → (f : C → A) (g : C → B) → Set l

--- a/src/Cubical/Retract.agda
+++ b/src/Cubical/Retract.agda
@@ -1,7 +1,7 @@
 module Cubical.Retract where
 
 open import Cubical
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 section : ∀ {ℓa ℓb} → {A : Set ℓa} → {B : Set ℓb} → (f : A → B) → (g : B → A) → Set ℓb
 section f g = ∀ b → f (g b) ≡ b

--- a/src/Cubical/Sigma.agda
+++ b/src/Cubical/Sigma.agda
@@ -6,7 +6,7 @@ module Cubical.Sigma where
 open import Cubical.PathPrelude
 open import Cubical.GradLemma
 open import Cubical.Sub
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.NType.Properties
 
 and : ∀ {ℓ} (A : Set ℓ) (B : Set ℓ) → Set ℓ

--- a/src/Cubical/Sigma.agda
+++ b/src/Cubical/Sigma.agda
@@ -7,6 +7,7 @@ open import Cubical.PathPrelude
 open import Cubical.GradLemma
 open import Cubical.Sub
 open import Cubical.FromStdLib
+open import Cubical.NType.Properties
 
 and : ∀ {ℓ} (A : Set ℓ) (B : Set ℓ) → Set ℓ
 and A B = Σ A (λ _ → B)

--- a/src/Cubical/Sub.agda
+++ b/src/Cubical/Sub.agda
@@ -2,7 +2,7 @@
 module Cubical.Sub where
 
 open import Cubical
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 
 -- "Sub A φ t" is another notation for "A[φ ↦ t]" as a type.
 

--- a/src/Cubical/Univalence.agda
+++ b/src/Cubical/Univalence.agda
@@ -5,7 +5,7 @@ open import Cubical hiding (_≃_; idEquiv)
 open import Cubical.FromStdLib
 open import Cubical.GradLemma
 open import Cubical.Retract
-
+open import Cubical.NType.Properties using (lemPropF ; propIsEquiv ; propSet)
 
 
 

--- a/src/Cubical/Univalence.agda
+++ b/src/Cubical/Univalence.agda
@@ -2,7 +2,7 @@
 module Cubical.Univalence where
 
 open import Cubical hiding (_≃_; idEquiv)
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.GradLemma
 open import Cubical.Retract
 open import Cubical.NType.Properties using (lemPropF ; propIsEquiv ; propSet)

--- a/src/Cubical/WrappedPath.agda
+++ b/src/Cubical/WrappedPath.agda
@@ -1,6 +1,6 @@
 {-# OPTIONS --cubical --postfix-projections #-}
 module Cubical.WrappedPath where
-open import Cubical.FromStdLib
+open import Cubical.Prelude
 open import Cubical.Primitives hiding (PathP; _≡_; Path)
 import Cubical.PathPrelude as P
 


### PR DESCRIPTION
Builds on top of https://github.com/Saizan/cubical-demo/pull/19

The idea is to isolate the module that redefines things from the standard library in it's own module and then subsequently expose these in another module `Cubical.Prelude`. Why? My idea is that I wan't to build this project *without* redefining things from the standard library. Perhaps using the C preprocessor - or perhaps simply by changing the contents of `Cubical.Prelude` to just import the standard library. This - of course is an annoying hack which won't be nearly as disturbing if I just do it in a module that is never touched.