### PR TITLE
A few results about preservation of homotopy level

### DIFF
--- a/src/Cubical/NType/Properties.agda
+++ b/src/Cubical/NType/Properties.agda
@@ -97,3 +97,26 @@ module _ {ℓa ℓb : Level} {A : Set ℓa} {B : Set ℓb} where
   -- Corollary 7.1.5 in HoTT.
   equivPreservesNType : {n : TLevel} → A ≃ B → HasLevel n A → HasLevel n B
   equivPreservesNType {n} eqv = transportNType {n = n} (Cubical.Retract.fromEquiv eqv)
+
+module _ {ℓ ℓ'} {A : Set ℓ} {B : A → Set ℓ'} where
+  -- Π preserves homotopy levels in the following sense:
+  contrPi : ((x : A) → isContr (B x)) → isContr ((x : A) → B x)
+  fst (contrPi h) a = fst (h a)
+  snd (contrPi h) π = funExt λ x →
+    let
+      allEq : ∀ y → fst (h x) ≡ y
+      allEq = snd (h x)
+      eq : fst (h x) ≡ π x
+      eq = allEq (π x)
+    in eq
+
+  postulate
+    -- This is example 3.1.6 in [HoTT] - would also follow from `piPresNType`
+    -- below (if that holds)
+    setPi
+      : ((x : A) → isSet (B x))
+      → isSet ((x : A) → B x)
+    piPresNType
+      : (n : TLevel)
+      → ((x : A) → HasLevel n (B x))
+      → HasLevel n ((x : A) → B x)

--- a/src/Cubical/Sigma.agda
+++ b/src/Cubical/Sigma.agda
@@ -285,3 +285,7 @@ sigPresNType {ℓb = ℓb} {A = A} {B} {S (S n)} ntA a→ntB (a₁ , b₁) (a₂
     equivl : V ≃ ((a₁ , b₁) ≡ (a₂ , b₂))
     equivl = pathToEquiv (sym (lemPathSig (a₁ , b₁) (a₂ , b₂)))
   in equivPreservesNType {n = S n} equivl prev
+
+module _ {ℓa ℓb : Level} {A : Set ℓa} {B : A → Set ℓb} where
+  sigPresSet : isSet A → (∀ a → isSet (B a)) → isSet (Σ A B)
+  sigPresSet = sigPresNType {n = S (S ⟨-2⟩)}

--- a/src/Cubical/Universe.agda
+++ b/src/Cubical/Universe.agda
@@ -1,0 +1,16 @@
+-- See §3.5 in [HoTT]
+module Cubical.Universe where
+
+open import Cubical.FromStdLib
+
+open import Cubical.NType
+
+module _ {ℓ : Level} where
+  hSet : TLevel → Set (ℓ-suc ℓ)
+  hSet n = Σ (Set ℓ) (HasLevel n)
+
+  0-Set : Set (ℓ-suc ℓ)
+  0-Set = hSet ⟨0⟩
+
+  Prop : Set (ℓ-suc ℓ)
+  Prop = hSet ⟨-2⟩


### PR DESCRIPTION
The only real new thing is that pi-types preserve contractibility. In that commit (eda16f3daf4759579f06b383225f944d84985c3f) I also snuck in a couple of postulates that I need.