### PR TITLE
[WIP] Define alternate ≃

### DIFF
--- a/src/Cubical/FromStdLib.agda
+++ b/src/Cubical/FromStdLib.agda
@@ -55,6 +55,7 @@ _∘_ : ∀ {a b c}
         (∀ {x} (y : B x) → C y) → (g : (x : A) → B x) →
         ((x : A) → C (g x))
 f ∘ g = λ x → f (g x)
+infixr 9 _∘_
 
 idFun : ∀ {ℓ} → (A : Set ℓ) → A → A
 idFun A x = x

--- a/src/Cubical/NType/Properties.agda
+++ b/src/Cubical/NType/Properties.agda
@@ -138,3 +138,10 @@ propHasLevel : ∀ {ℓ} {A : Set ℓ} n → isProp (HasLevel n A)
 propHasLevel ⟨-2⟩ = propIsContr
 propHasLevel (S ⟨-2⟩) = lemProp λ p → piPresNType ⟨-1⟩ \ x → piPresNType ⟨-1⟩ \ y → propSet p _ _
 propHasLevel (S m@(S n)) = piPresNType ⟨-1⟩ \ x → piPresNType ⟨-1⟩ \ y → propHasLevel m
+
+module _ {ℓ : Level} {A : Set ℓ} where
+  isSetIsProp : isProp (isSet A)
+  isSetIsProp = propHasLevel (S (S ⟨-2⟩))
+
+  propIsProp : isProp (isProp A)
+  propIsProp = propHasLevel (S ⟨-2⟩)


### PR DESCRIPTION
This moves the alternate definition of ≃ previously found in
Cubical.Univalence to Cubical.PathPrelude. Further, it prepares for
using this definition everywhere and not having to congruent definitions
of equivalence lying around.

This is work in progress because swapping out the definitions
immediately will result in errors relating to the new definition not
having eta-equality.