### PR TITLE
[WIP] Move definition of equivalence to own module

### DIFF
--- a/src/Cubical/Equivalence.agda
+++ b/src/Cubical/Equivalence.agda
@@ -1,0 +1,63 @@
+module Cubical.Equivalence where
+
+open import Cubical.FromStdLib
+open import Cubical.Primitives
+open import Cubical.NType public using (isContr)
+
+fiber : ∀ {ℓ ℓ'} {E : Set ℓ} {B : Set ℓ'} (f : E → B) (y : B) → Set (ℓ-max ℓ ℓ')
+fiber {E = E} f y = Σ[ x ∈ E ] y ≡ f x
+
+module _ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') where
+  isEquiv : (A → B) → Set (ℓ-max ℓ ℓ')
+  isEquiv f = (y : B) → isContr (fiber f y)
+
+{-# BUILTIN ISEQUIV isEquiv #-}
+
+module _ {ℓa ℓb : Level} (A : Set ℓa) (B : Set ℓb) where
+  private
+    ℓ = ℓ-max ℓa ℓb
+
+  record AreInverses (f : A → B) (g : B → A) : Set ℓ where
+    field
+      verso-recto : g ∘ f ≡ idFun A
+      recto-verso : f ∘ g ≡ idFun B
+
+  Isomorphism : (f : A → B) → Set _
+  Isomorphism f = Σ (B → A) λ g → AreInverses f g
+
+  _≅_ : Set ℓ
+  _≅_ = Σ _ Isomorphism
+
+  record _≃_ : Set ℓ where
+    no-eta-equality
+    constructor con
+    field
+      eqv : A → B
+      isEqv : isEquiv A B eqv
+
+    -- FIXME I wanna replace the field with named `eqv` with this.
+    obverse : A → B
+    obverse = eqv
+
+    inverse : B → A
+    inverse b = fst (fst (isEqv b))
+
+    -- We can extract an isomorphism from an equivalence.
+    --
+    -- One way to do it would be to use univalence and coersion - but there's
+    -- probably a more straight-forward way that does not require breaking the
+    -- dependency graph between this module and Cubical.Univalence
+    areInverses : AreInverses obverse inverse
+    areInverses = record
+      { verso-recto = verso-recto
+      ; recto-verso = recto-verso
+      }
+      where
+      postulate
+        verso-recto : inverse ∘ obverse ≡ idFun A
+        recto-verso : obverse ∘ inverse ≡ idFun B
+
+    toIsomorphism : _≅_
+    toIsomorphism = obverse , (inverse , areInverses)
+
+    open AreInverses areInverses public

--- a/src/Cubical/Equivalence.agda
+++ b/src/Cubical/Equivalence.agda
@@ -1,7 +1,7 @@
 module Cubical.Equivalence where
 
 open import Cubical.FromStdLib
-open import Cubical.Primitives
+open import Cubical.Primitives using (_≡_)
 open import Cubical.NType public using (isContr)
 
 fiber : ∀ {ℓ ℓ'} {E : Set ℓ} {B : Set ℓ'} (f : E → B) (y : B) → Set (ℓ-max ℓ ℓ')

--- a/src/Cubical/NType/Properties.agda
+++ b/src/Cubical/NType/Properties.agda
@@ -138,3 +138,10 @@ propHasLevel : ∀ {ℓ} {A : Set ℓ} n → isProp (HasLevel n A)
 propHasLevel ⟨-2⟩ = propIsContr
 propHasLevel (S ⟨-2⟩) = lemProp λ p → piPresNType ⟨-1⟩ \ x → piPresNType ⟨-1⟩ \ y → propSet p _ _
 propHasLevel (S m@(S n)) = piPresNType ⟨-1⟩ \ x → piPresNType ⟨-1⟩ \ y → propHasLevel m
+
+module _ {ℓ : Level} {A : Set ℓ} where
+  isSetIsProp : isProp (isSet A)
+  isSetIsProp = propHasLevel (S (S ⟨-2⟩))
+
+  propIsProp : isProp (isProp A)
+  propIsProp = propHasLevel (S ⟨-2⟩)

--- a/src/Cubical/PathPrelude.agda
+++ b/src/Cubical/PathPrelude.agda
@@ -7,7 +7,7 @@ open import Cubical.FromStdLib
 open import Cubical.NType public using (isContr ; isProp ; isSet)
 -- NB! This module does *not* use the same notion of equivalence `_≃_` as
 -- defined in Cubical.Equivalence!
-open import Cubical.Equivalence hiding (_≃_) public
+open import Cubical.Equivalence using (fiber ; isEquiv) public
 
 module _ {ℓ} {A : Set ℓ} where
   refl : {x : A} → x ≡ x

--- a/src/Cubical/PathPrelude.agda
+++ b/src/Cubical/PathPrelude.agda
@@ -5,6 +5,9 @@ open import Cubical.Primitives public
 open import Cubical.Primitives public using () renaming (Sub to _[_↦_])
 open import Cubical.FromStdLib
 open import Cubical.NType public using (isContr ; isProp ; isSet)
+-- NB! This module does *not* use the same notion of equivalence `_≃_` as
+-- defined in Cubical.Equivalence!
+open import Cubical.Equivalence hiding (_≃_) public
 
 module _ {ℓ} {A : Set ℓ} where
   refl : {x : A} → x ≡ x
@@ -175,15 +178,9 @@ module _ {ℓ ℓ' : I → Level} {T : ∀ i → Set (ℓ i)} {A : ∀ i → Set
   pres j = unsafeComp A (φ ∨ (j ∨ ~ j)) (λ i → primPOr φ (j ∨ ~ j)
     (a i) \ { (j = i1) → f i (v i); (j = i0) → u i}) a0
 
-fiber : ∀ {ℓ ℓ'} {E : Set ℓ} {B : Set ℓ'} (f : E → B) (y : B) → Set (ℓ-max ℓ ℓ')
-fiber {E = E} f y = Σ[ x ∈ E ] y ≡ f x
-
 module _ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') where
-  isEquiv : (A → B) → Set (ℓ-max ℓ ℓ')
-  isEquiv f = (y : B) → isContr (fiber f y)
-
   infix 4 _≃_
-  _≃_ = Σ _ isEquiv
+  _≃_ = Σ _ (isEquiv A B)
 
   module _ (f : _≃_) (φ : I) (t : Partial A φ) (a : B {- [ φ ↦ f t ] -})
            (p : PartialP φ (λ o → a ≡ fst f (t o))) where
@@ -195,8 +192,6 @@ module _ {ℓ ℓ'} (A : Set ℓ) (B : Set ℓ') where
 
     equivProof : a ≡ fst f equivFunc
     equivProof = snd equiv
-
-{-# BUILTIN ISEQUIV isEquiv #-}
 
 -- | The isomorphism going in the opposite direction induced by an equivalence.
 module _ {ℓ ℓ'} {A : Set ℓ} {B : Set ℓ'} where

--- a/src/Cubical/Univalence.agda
+++ b/src/Cubical/Univalence.agda
@@ -1,23 +1,14 @@
 {-# OPTIONS --cubical  #-}
 module Cubical.Univalence where
 
-open import Cubical hiding (_≃_; idEquiv)
+open import Cubical hiding (_≃_; idEquiv ; inverse)
 open import Cubical.FromStdLib
 open import Cubical.GradLemma
 open import Cubical.Retract
 open import Cubical.NType.Properties using (lemPropF ; propIsEquiv ; propSet)
-
-
-
-record _≃_ {ℓa ℓb} (A : Set ℓa)(B : Set ℓb) : Set (ℓ-max ℓa ℓb) where
-  no-eta-equality
-  constructor con
-  field
-    eqv : A → B
-    isEqv : isEquiv A B eqv
+open import Cubical.Equivalence
 
 open _≃_
-
 
 idEquiv : ∀ {ℓ} {A : Set ℓ} → A ≃ A
 idEquiv .eqv = idFun _


### PR DESCRIPTION
This is a refactor along with some added symbols in Cubical.Equivalence.
This is work in progress because that module has some open goals.